### PR TITLE
Pass name in formatter options

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -15,9 +15,10 @@
   "efficient": "always",
   "exclude": [],
   "extendPref": false,
-  "formatterOptions": {
+  "formatter": {
     "columns": ["lineData", "severity", "message", "rule"],
     "columnSplitter": "  ",
+    "name": "default",
     "showHeaders": false,
     "truncate": true
   },

--- a/README.md
+++ b/README.md
@@ -197,9 +197,10 @@ Note that customProperties and mixins are aliases
 	"placeholders": "always",
 	"prefixVarsWithDollar": "always",
 	"quotePref": false,
-	"formatterOptions": {
+	"formatter": {
 		"columns": ["lineData", "severity", "description", "rule"],
 		"columnSplitter": "  ",
+		"name": "default",
 		"showHeaders": false,
 		"truncate": true
 	},
@@ -583,7 +584,7 @@ Example if `'single'`: prefer `$var = 'some string'` over `$var = "some string"`
 Example if `'double'`: prefer `$var = "some string"` over `$var = 'some string'`
 
 
-### formatterOptions ( Object )
+### formatter ( Object )
 These options are used by the selected formatter to adjust the final output, when supported.
 
 Default options:
@@ -591,6 +592,7 @@ Default options:
 {
 	columns: ['lineData', 'severity', 'description', 'rule'],
 	columnSplitter: '  ',
+	name: 'default',
 	showHeaders: false,
 	truncate: true
 }

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -32,9 +32,10 @@ const config = {
   // group formatter output by file or go sequentially
   groupOutputByFile: true,
   // manipulate terminal output with or without an additional formatter
-  formatterOptions: {
+  formatter: {
     columnSplitter: '  ',
     columns: ['lineData', 'severity', 'message', 'rule'],
+    name: 'default',
     showHeaders: false,
     truncate: true,
   },

--- a/src/core/done.js
+++ b/src/core/done.js
@@ -29,7 +29,7 @@ const done = function() {
       maxErrors,
       maxWarnings,
       groupOutputByFile: this.config.groupOutputByFile,
-      formatterOptions: this.config.formatterOptions,
+      formatterOptions: this.config.formatter,
     },
     shouldKill
   );

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -8,7 +8,7 @@ const defaultOptions = {
   config: null,
   strict: false,
   callback() {},
-  formatter: 'default',
+  formatter: null,
 };
 
 /**
@@ -22,7 +22,9 @@ const init = function(options, pathPassed) {
   const optionsWithDefaults = defaults(options || {}, defaultOptions);
 
   this.config = this.setConfig(optionsWithDefaults.config);
-  this.formatter = getFormatter(optionsWithDefaults.formatter);
+
+  const formatterName = optionsWithDefaults.formatter || this.config.formatter.name;
+  this.formatter = getFormatter(formatterName);
 
   // if you want to use transparent mixins, pass in an array of them
   // this also covers the (more common probably) custom property use case

--- a/test/core/done.test.js
+++ b/test/core/done.test.js
@@ -154,7 +154,7 @@ describe('done', () => {
 
     it('should pass along groupOutputByFile and formatterOptions', () => {
       context.config.groupOutputByFile = true;
-      context.config.formatterOptions = true;
+      context.config.formatter = true;
 
       done.call(context);
 

--- a/test/core/init.test.js
+++ b/test/core/init.test.js
@@ -47,12 +47,21 @@ describe('Init should: ', () => {
   });
 
   it('set formatter to the value returned by the formatter retrieval method', () => {
+    app.init();
+
+    expect(app.formatter).toEqual(mockFormatterValue);
+  });
+
+  it('use formatter from user options if provided', () => {
     const options = { formatter: 'woot woot' };
 
     app.init(options);
-
     expect(mockGetFormatter).toHaveBeenLastCalledWith(options.formatter);
-    expect(app.formatter).toEqual(mockFormatterValue);
+  });
+
+  it('use formatter from configuration options if user formatter is not provided', () => {
+    app.init();
+    expect(mockGetFormatter).toHaveBeenLastCalledWith(app.config.formatter.name);
   });
 
   it('use custom config if passed --config flag', () => {

--- a/test/core/init.test.js
+++ b/test/core/init.test.js
@@ -49,7 +49,7 @@ describe('Init should: ', () => {
   it('set formatter to the value returned by the formatter retrieval method', () => {
     app.init();
 
-    expect(app.formatter).toEqual(mockFormatterValue);
+    expect(app.formatter).toBe(mockFormatterValue);
   });
 
   it('use formatter from user options if provided', () => {


### PR DESCRIPTION
## Issues
* https://github.com/SimenB/stylint/issues/354

## Changes
* Rename `formatterOptions` to `formatter`
* Add `name` key to `formatter` configuration
* Update documentation

## Code Coverage
<img width="758" alt="screen shot 2017-09-07 at 12 14 47 am" src="https://user-images.githubusercontent.com/4430224/30150779-95af73b4-9361-11e7-879c-47c7e89858a4.png">

![getinsertpic.com](https://media2.giphy.com/media/pNpONEEg3pLIQ/200.gif)